### PR TITLE
Changed mssql images to 2017-latest and 2022-latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Although it provides analogous declaritive means for database structure descript
 Also provides declarative means for database structure description with different syntax, but publishing process is entirely different and relies on dragging the whole history of every change done to database. Also DotNetDBTools is not an ORM, it just provides means to describe and deploy database structure and analysis on this structure.
 
 # Supported DBMS
-+ MSSQL (oldest tested - 2017-GA, latest tested - 2019-CU18)
++ MSSQL (oldest tested - 2017, latest tested - 2022)
 + MySQL ((minimal required - 8.0.19, latest tested - 8.0.31)
 + PostgreSQL ((oldest tested - 11.0, latest tested - 15.1)
 + SQLite ((minimal required - 3.26.0, latest tested - 3.39.2)

--- a/tests/DotNetDBTools.IntegrationTests/MSSQL/MSSQLContainerHelper.cs
+++ b/tests/DotNetDBTools.IntegrationTests/MSSQL/MSSQLContainerHelper.cs
@@ -15,8 +15,8 @@ internal class MSSQLContainerHelper
 
     private static string MSSQLImageTag =>
         Environment.GetEnvironmentVariable("DNDBT_USE_LATEST_DBMS_VERSION") != "true"
-        ? "2017-GA-ubuntu"
-        : "2019-CU18-ubuntu-20.04";
+        ? "2017-latest"
+        : "2022-latest";
 
     public static string MSSQLContainerConnectionString =>
         new SqlConnectionStringBuilder()


### PR DESCRIPTION
Using 2017-latest image tag should fix integration tests error (because 2017-GA-ubuntu apparently does not support tls1.2):
`Unhandled exception. System.Data.SqlClient.SqlException (0x80131904): A connection was successfully established with the server, but then an error occurred during the pre-login handshake. (provider: SSL Provider, error: 31 - Encryption(ssl/tls) handshake failed)
 ---> System.IO.EndOfStreamException: End of stream reached`